### PR TITLE
Allow setting hostname for localstack deployement

### DIFF
--- a/bin/chalice-local
+++ b/bin/chalice-local
@@ -17,7 +17,10 @@ from localstack_client.config import get_service_endpoint
 
 
 def create_client(self, service, *args, **kwargs):
-    kwargs['endpoint_url'] = get_service_endpoint(service)
+    kwargs['endpoint_url'] = get_service_endpoint(
+        service, 
+        os.environ['LOCALSTACK_HOST'] or 'localhost'
+    )    
     result = create_client_orig(self, service, *args, **kwargs)
     return result
 


### PR DESCRIPTION
Allow setting hostname for localstack deployement with LOCALSTACK_HOST environment variable.

Useful for using localstack inside of a dev docker environment.