### PR TITLE
update links to LocalStack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AWS Chalice Client for LocalStack
 
 This project provides `chalice-local`, a small wrapper script to use
-[AWS Chalice](https://github.com/aws/chalice) with [LocalStack](https://github.com/localstack/localstack).
+[AWS Chalice](https://github.com/aws/chalice) with [LocalStack for AWS](https://www.localstack.cloud/localstack-for-aws).
 
 ## Installing
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ if __name__ == '__main__':
         description='Small wrapper script to use AWS Chalice with LocalStack',
         author='LocalStack Team',
         author_email='info@localstack.cloud',
-        url='https://github.com/localstack/localstack',
+        url='https://www.localstack.cloud',
         scripts=['bin/chalice-local', 'bin/chalice-local.bat'],
         packages=find_packages(exclude=('tests', 'tests.*')),
         package_data=package_data,


### PR DESCRIPTION
## Motivation
The README and the `setup.py` currently points towards the GitHub repo `localstack/localstack`. After the [consolidation of our images](https://blog.localstack.cloud/the-road-ahead-for-localstack/) this repo will not be the primary point for our code though.
This is why this PR updates these links to point towards our website.

## Changes
- Update link in README and `setup.py`.